### PR TITLE
Ensure custom sales document printing is used

### DIFF
--- a/comerzzia-bricodepot-api-omnichannel/pom.xml
+++ b/comerzzia-bricodepot-api-omnichannel/pom.xml
@@ -89,16 +89,26 @@
 			<artifactId>mybatis-spring</artifactId>
 			<version>1.3.2</version>
 		</dependency>
-		<dependency>
-			<groupId>org.mybatis.dynamic-sql</groupId>
-			<artifactId>mybatis-dynamic-sql</artifactId>
-			<version>1.1.4</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.ws.rs</groupId>
-			<artifactId>javax.ws.rs-api</artifactId>
-			<version>2.1.1</version>
-		</dependency>
+                <dependency>
+                        <groupId>org.mybatis.dynamic-sql</groupId>
+                        <artifactId>mybatis-dynamic-sql</artifactId>
+                        <version>1.1.4</version>
+                </dependency>
+                <dependency>
+                        <groupId>net.sf.jasperreports</groupId>
+                        <artifactId>jasperreports</artifactId>
+                        <version>6.21.3</version>
+                </dependency>
+                <dependency>
+                        <groupId>com.google.zxing</groupId>
+                        <artifactId>core</artifactId>
+                        <version>3.5.3</version>
+                </dependency>
+                <dependency>
+                        <groupId>javax.ws.rs</groupId>
+                        <artifactId>javax.ws.rs-api</artifactId>
+                        <version>2.1.1</version>
+                </dependency>
 		<!-- comerzzia dependencies -->
 		<dependency>
 			<groupId>com.comerzzia</groupId>

--- a/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/api/omnichannel/web/rest/salesdoc/SalesDocumentResource.java
+++ b/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/api/omnichannel/web/rest/salesdoc/SalesDocumentResource.java
@@ -22,13 +22,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.util.InvalidMimeTypeException;
 
 import com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument.SalesDocumentPrintResponse;
 import com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument.SalesDocumentPrintService;
 
-@Component
 @Path("/salesdocument")
 public class SalesDocumentResource {
 

--- a/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/config/SalesDocumentResourceConfiguration.java
+++ b/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/config/SalesDocumentResourceConfiguration.java
@@ -1,0 +1,28 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import com.comerzzia.api.omnichannel.web.rest.salesdoc.SalesDocumentResource;
+import com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument.SalesDocumentPrintService;
+
+/**
+ * Registers the custom sales document resource so that Jersey always uses the
+ * version implemented for Brico Depot.
+ */
+@Configuration
+public class SalesDocumentResourceConfiguration {
+
+    private final SalesDocumentPrintService salesDocumentPrintService;
+
+    public SalesDocumentResourceConfiguration(SalesDocumentPrintService salesDocumentPrintService) {
+        this.salesDocumentPrintService = salesDocumentPrintService;
+    }
+
+    @Bean("salesDocumentResource")
+    @Primary
+    public SalesDocumentResource salesDocumentResource() {
+        return new SalesDocumentResource(salesDocumentPrintService);
+    }
+}


### PR DESCRIPTION
## Summary
- add explicit JasperReports and ZXing dependencies required to render ticket PDFs
- register the Brico Depot specific sales document resource so Jersey resolves the customised implementation
- instantiate the resource through a dedicated configuration class to guarantee the custom print service is injected

## Testing
- mvn -pl comerzzia-bricodepot-api-omnichannel -am -DskipTests package *(fails: missing proprietary Comerzzia repositories in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de4561b124832bac2b2b4953ce8636