### PR TITLE
Renombrar componentes de impresión de documentos de venta

### DIFF
--- a/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionController.java
+++ b/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionController.java
@@ -1,0 +1,73 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.comerzzia.api.core.services.session.SessionService;
+import com.comerzzia.core.servicios.sesion.IDatosSesion;
+
+@RestController
+@RequestMapping("/salesdocument")
+public class DocumentoVentaImpresionController {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DocumentoVentaImpresionController.class);
+
+    private final DocumentoVentaImpresionServicio servicioImpresion;
+    private final SessionService servicioSesion;
+
+    @Autowired
+    public DocumentoVentaImpresionController(DocumentoVentaImpresionServicio servicioImpresion,
+                                             SessionService servicioSesion) {
+        this.servicioImpresion = servicioImpresion;
+        this.servicioSesion = servicioSesion;
+    }
+
+    @GetMapping(value = "/{documentUid}/print")
+    public ResponseEntity<DocumentoVentaImpresionRespuesta> imprimir(
+            @PathVariable("documentUid") String uidDocumento,
+            @RequestParam(value = "mimeType", required = false, defaultValue = "application/pdf") String tipoMime,
+            @RequestParam(value = "copy", required = false, defaultValue = "false") boolean esCopia,
+            @RequestParam(value = "inline", required = false, defaultValue = "false") boolean enLinea,
+            @RequestParam(value = "outputDocumentName", required = false) String nombreDocumentoSalida,
+            @RequestParam(value = "printTemplate", required = false) String plantillaImpresion,
+            @RequestParam Map<String, String> parametrosPeticion) {
+
+        Map<String, String> parametrosPersonalizados = new HashMap<>(parametrosPeticion);
+        parametrosPersonalizados.remove("mimeType");
+        parametrosPersonalizados.remove("copy");
+        parametrosPersonalizados.remove("inline");
+        parametrosPersonalizados.remove("outputDocumentName");
+        parametrosPersonalizados.remove("printTemplate");
+
+        OpcionesImpresionDocumentoVenta opciones = new OpcionesImpresionDocumentoVenta(
+                tipoMime,
+                esCopia,
+                enLinea,
+                nombreDocumentoSalida,
+                plantillaImpresion,
+                parametrosPersonalizados);
+
+        IDatosSesion datosSesion = servicioSesion.getDatosSesion();
+        if (datosSesion == null) {
+            LOGGER.warn("imprimir() - No se pudieron obtener los datos de sesión para la petición actual");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        Optional<DocumentoVentaImpresionRespuesta> respuesta =
+                servicioImpresion.imprimir(uidDocumento, opciones, datosSesion);
+
+        return respuesta.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.ok().body(null));
+    }
+}

--- a/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionException.java
+++ b/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionException.java
@@ -1,0 +1,14 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument;
+
+public class DocumentoVentaImpresionException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public DocumentoVentaImpresionException(String mensaje) {
+        super(mensaje);
+    }
+
+    public DocumentoVentaImpresionException(String mensaje, Throwable causa) {
+        super(mensaje, causa);
+    }
+}

--- a/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionRespuesta.java
+++ b/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionRespuesta.java
@@ -1,0 +1,76 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class DocumentoVentaImpresionRespuesta implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("documentUid")
+    private String uidDocumento;
+
+    @JsonProperty("mimeType")
+    private String tipoMime;
+
+    @JsonProperty("fileName")
+    private String nombreArchivo;
+
+    @JsonProperty("copy")
+    private boolean copia;
+
+    @JsonProperty("inline")
+    private boolean enLinea;
+
+    @JsonProperty("document")
+    private String documento;
+
+    public String getUidDocumento() {
+        return uidDocumento;
+    }
+
+    public void setUidDocumento(String uidDocumento) {
+        this.uidDocumento = uidDocumento;
+    }
+
+    public String getTipoMime() {
+        return tipoMime;
+    }
+
+    public void setTipoMime(String tipoMime) {
+        this.tipoMime = tipoMime;
+    }
+
+    public String getNombreArchivo() {
+        return nombreArchivo;
+    }
+
+    public void setNombreArchivo(String nombreArchivo) {
+        this.nombreArchivo = nombreArchivo;
+    }
+
+    public boolean isCopia() {
+        return copia;
+    }
+
+    public void setCopia(boolean copia) {
+        this.copia = copia;
+    }
+
+    public boolean isEnLinea() {
+        return enLinea;
+    }
+
+    public void setEnLinea(boolean enLinea) {
+        this.enLinea = enLinea;
+    }
+
+    public String getDocumento() {
+        return documento;
+    }
+
+    public void setDocumento(String documento) {
+        this.documento = documento;
+    }
+}

--- a/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionServicio.java
+++ b/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/DocumentoVentaImpresionServicio.java
@@ -1,0 +1,359 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.ibatis.session.SqlSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+import com.comerzzia.aena.util.xml.MarshallUtil;
+import com.comerzzia.core.model.actividades.ActividadBean;
+import com.comerzzia.core.model.empresas.EmpresaBean;
+import com.comerzzia.core.model.informes.TrabajoInformeBean;
+import com.comerzzia.core.model.tiposdocumentos.TipoDocumentoBean;
+import com.comerzzia.core.model.ventas.tickets.TicketBean;
+import com.comerzzia.core.servicios.empresas.ServicioEmpresasImpl;
+import com.comerzzia.core.servicios.instancias.ServicioInstanciasImpl;
+import com.comerzzia.core.servicios.sesion.IDatosSesion;
+import com.comerzzia.core.servicios.tipodocumento.ServicioTiposDocumentosImpl;
+import com.comerzzia.core.servicios.tipodocumento.TipoDocumentoException;
+import com.comerzzia.core.servicios.tipodocumento.TipoDocumentoNotFoundException;
+import com.comerzzia.core.servicios.ventas.tickets.ServicioTicketsImpl;
+import com.comerzzia.core.util.config.AppInfo;
+import com.comerzzia.core.util.db.Database;
+import com.comerzzia.core.util.xml.XMLDocument;
+import com.comerzzia.core.util.xml.XMLDocumentNode;
+import com.comerzzia.core.util.xml.XMLDocumentNodeNotFoundException;
+import com.comerzzia.model.fidelizacion.tarjetas.TarjetaBean;
+import com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.LineaTicket;
+import com.comerzzia.omnichannel.documentos.facturas.converters.albaran.ticket.TicketVentaAbono;
+import com.comerzzia.servicios.fidelizacion.tarjetas.ServicioTarjetasImpl;
+import com.comerzzia.servicios.fidelizacion.tarjetas.TarjetaNotFoundException;
+
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JasperRunManager;
+import net.sf.jasperreports.engine.util.JRLoader;
+
+@Service
+public class DocumentoVentaImpresionServicio {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DocumentoVentaImpresionServicio.class);
+
+    private static final DateTimeFormatter FORMATO_FECHA_IMPRESION = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    private static final String PAIS_PORTUGAL = "PT";
+    private static final String PAIS_CATALUNA = "CA";
+    private static final String MIMETYPE_POR_DEFECTO = "application/pdf";
+    private static final String DIRECTORIO_INFORMES = "ventas/facturas/";
+
+    private final ServicioTiposDocumentosImpl servicioTiposDocumentos;
+    private final ServicioEmpresasImpl servicioEmpresas;
+    private final com.comerzzia.bricodepot.backoffice.services.ventas.facturas.CargarFacturaA4Servicio servicioCargaFactura;
+
+    @Autowired
+    public DocumentoVentaImpresionServicio(ServicioTiposDocumentosImpl servicioTiposDocumentos,
+                                           ServicioEmpresasImpl servicioEmpresas,
+                                           com.comerzzia.bricodepot.backoffice.services.ventas.facturas.CargarFacturaA4Servicio servicioCargaFactura) {
+        this.servicioTiposDocumentos = servicioTiposDocumentos;
+        this.servicioEmpresas = servicioEmpresas;
+        this.servicioCargaFactura = servicioCargaFactura;
+    }
+
+    public Optional<DocumentoVentaImpresionRespuesta> imprimir(String uidDocumento,
+                                                               OpcionesImpresionDocumentoVenta opciones,
+                                                               IDatosSesion datosSesion) {
+        if (StringUtils.isBlank(uidDocumento)) {
+            throw new DocumentoVentaImpresionException("El identificador del documento es obligatorio");
+        }
+        try {
+            TicketBean ticket = ServicioTicketsImpl.get().consultarTicketUid(uidDocumento, datosSesion.getUidActividad());
+            if (ticket == null) {
+                LOGGER.warn("imprimir() - No se encontró el documento de venta con uid '{}'", uidDocumento);
+                return Optional.empty();
+            }
+
+            TicketVentaAbono ticketVenta = convertirTicket(ticket);
+            TrabajoInformeBean trabajoInforme = prepararTrabajoInforme(ticket, ticketVenta, opciones, datosSesion);
+            anadirParametrosPersonalizados(trabajoInforme, opciones.getParametrosPersonalizados());
+
+            TipoDocumentoBean tipoDocumento = obtenerTipoDocumento(ticketVenta, datosSesion);
+            String plantillaJasper = resolverPlantilla(ticketVenta, tipoDocumento, opciones.getPlantillaImpresion());
+            byte[] pdf = generarPdf(trabajoInforme, plantillaJasper);
+
+            DocumentoVentaImpresionRespuesta respuesta = construirRespuesta(uidDocumento, opciones, pdf);
+            return Optional.of(respuesta);
+        }
+        catch (DocumentoVentaImpresionException excepcion) {
+            throw excepcion;
+        }
+        catch (Exception excepcion) {
+            throw new DocumentoVentaImpresionException("No fue posible generar el PDF del documento de venta", excepcion);
+        }
+    }
+
+    private TicketVentaAbono convertirTicket(TicketBean ticket) {
+        try {
+            return (TicketVentaAbono) MarshallUtil.leerXML(ticket.getTicket(), TicketVentaAbono.class);
+        }
+        catch (Exception excepcion) {
+            LOGGER.error("convertirTicket() - Error al interpretar el XML del ticket", excepcion);
+            throw new DocumentoVentaImpresionException("No fue posible interpretar el ticket recibido", excepcion);
+        }
+    }
+
+    private TrabajoInformeBean prepararTrabajoInforme(TicketBean ticket,
+                                                      TicketVentaAbono ticketVenta,
+                                                      OpcionesImpresionDocumentoVenta opciones,
+                                                      IDatosSesion datosSesion) throws Exception {
+        TrabajoInformeBean trabajoInforme = new TrabajoInformeBean();
+        trabajoInforme.addParametro("ticket", ticketVenta);
+        trabajoInforme.addParametro("ticketVentaAbono", ticketVenta);
+        trabajoInforme.addParametro("esDuplicado", opciones.esCopia());
+        trabajoInforme.addParametro("DEVOLUCION", esDevolucion(ticketVenta));
+        trabajoInforme.addParametro("UID_ACTIVIDAD", datosSesion.getUidActividad());
+
+        if (ticket.getFecha() != null) {
+            trabajoInforme.addParametro("FECHA_TICKET", ticket.getFecha());
+        }
+        if (StringUtils.isNotBlank(ticket.getLocatorId())) {
+            trabajoInforme.addParametro("LOCATOR_ID", ticket.getLocatorId());
+        }
+
+        agregarLogoEmpresa(trabajoInforme, ticket, datosSesion);
+        agregarDatosActividad(trabajoInforme, ticket);
+        servicioCargaFactura.addFiscalData(ticket, trabajoInforme);
+        cargarInformacionPagos(ticket, ticketVenta, trabajoInforme, datosSesion);
+        servicioCargaFactura.cargarPromociones(ticket, trabajoInforme);
+        agregarTotalesTarjetaRegalo(trabajoInforme, ticketVenta, datosSesion);
+        agregarMetadatosFactura(trabajoInforme, ticket);
+        agregarDirectoriosInformes(trabajoInforme);
+        agregarLineasAgrupadas(trabajoInforme, ticketVenta);
+        marcarCopia(trabajoInforme, opciones);
+        agregarMetadatosPersonalizados(trabajoInforme, ticket);
+
+        return trabajoInforme;
+    }
+
+    private void agregarLogoEmpresa(TrabajoInformeBean trabajoInforme,
+                                     TicketBean ticket,
+                                     IDatosSesion datosSesion) throws IOException {
+        try (SqlSession sesionSql = Database.getSqlSession()) {
+            EmpresaBean empresa = servicioEmpresas.consultar(sesionSql, ticket.getCodemp(), datosSesion.getUidActividad());
+            if (empresa != null && empresa.getLogotipo() != null) {
+                InputStream logotipo = new ByteArrayInputStream(empresa.getLogotipo());
+                trabajoInforme.addParametro("LOGO", logotipo);
+            }
+        }
+    }
+
+    private void agregarDatosActividad(TrabajoInformeBean trabajoInforme, TicketBean ticket) throws Exception {
+        ActividadBean actividad = ServicioInstanciasImpl.get().consultarActividad(ticket.getUidActividad());
+        if (actividad != null) {
+            trabajoInforme.addParametro("UID_INSTANCIA", actividad.getUidInstancia());
+        }
+    }
+
+    private void cargarInformacionPagos(TicketBean ticket,
+                                        TicketVentaAbono ticketVenta,
+                                        TrabajoInformeBean trabajoInforme,
+                                        IDatosSesion datosSesion) throws Exception {
+        servicioCargaFactura.getPagoGiftCard(ticketVenta, trabajoInforme);
+        servicioCargaFactura.generarMediosPago(ticketVenta, datosSesion);
+        servicioCargaFactura.cargarDatosPagoTarjeta(ticket, ticketVenta, trabajoInforme);
+    }
+
+    private void agregarTotalesTarjetaRegalo(TrabajoInformeBean trabajoInforme,
+                                             TicketVentaAbono ticketVenta,
+                                             IDatosSesion datosSesion) throws TarjetaNotFoundException {
+        if (ticketVenta.getCabecera().getTarjetaRegalo() == null) {
+            return;
+        }
+        String numerosTarjeta = ticketVenta.getCabecera().getTarjetaRegalo().getNumTarjetaRegalo();
+        if (StringUtils.isBlank(numerosTarjeta)) {
+            return;
+        }
+        String[] tarjetasSeparadas = StringUtils.split(numerosTarjeta, '/');
+        List<String> tarjetas = tarjetasSeparadas != null
+                ? Arrays.asList(tarjetasSeparadas)
+                : Collections.singletonList(numerosTarjeta);
+
+        double saldoTotal = 0.0d;
+        for (String numeroTarjeta : tarjetas) {
+            TarjetaBean tarjeta = ServicioTarjetasImpl.get().consultarTarjetaPorNumero(numeroTarjeta, datosSesion);
+            if (tarjeta != null) {
+                saldoTotal += tarjeta.getSaldoProvisional() + tarjeta.getSaldo();
+            }
+        }
+        trabajoInforme.addParametro("totalSaldoGiftCard", saldoTotal);
+    }
+
+    private void agregarMetadatosFactura(TrabajoInformeBean trabajoInforme, TicketBean ticket)
+            throws XMLDocumentNodeNotFoundException {
+        Document documento = ticket.getXml();
+        if (documento == null) {
+            return;
+        }
+        String fechaOrigen = obtenerFechaOrigen(documento);
+        if (fechaOrigen != null) {
+            trabajoInforme.addParametro("fecha_origen", fechaOrigen);
+        }
+        String numeroPedido = obtenerNumeroPedido(documento);
+        if (StringUtils.isNotBlank(numeroPedido)) {
+            trabajoInforme.addParametro("numPedido", numeroPedido);
+        }
+    }
+
+    private void agregarDirectoriosInformes(TrabajoInformeBean trabajoInforme) {
+        String rutaBase = AppInfo.getInformesInfo().getRutaBase();
+        if (StringUtils.isBlank(rutaBase)) {
+            rutaBase = "." + File.separator;
+        }
+        trabajoInforme.addParametro("SUBREPORT_DIR", rutaBase + DIRECTORIO_INFORMES);
+    }
+
+    private void agregarLineasAgrupadas(TrabajoInformeBean trabajoInforme, TicketVentaAbono ticketVenta) {
+        List<LineaTicket> lineasAgrupadas = servicioCargaFactura.getLineasAgrupadas(ticketVenta, trabajoInforme);
+        trabajoInforme.addParametro("lineasAgrupadas", lineasAgrupadas);
+    }
+
+    private void marcarCopia(TrabajoInformeBean trabajoInforme, OpcionesImpresionDocumentoVenta opciones) {
+        if (opciones.esCopia()) {
+            trabajoInforme.addParametro("esDuplicado", Boolean.TRUE);
+        }
+    }
+
+    private void agregarMetadatosPersonalizados(TrabajoInformeBean trabajoInforme, TicketBean ticket) {
+        trabajoInforme.addParametro("print_timestamp", FORMATO_FECHA_IMPRESION.format(LocalDateTime.now()));
+        trabajoInforme.addParametro("ticket_uid", ticket.getUidTicket());
+    }
+
+    private void anadirParametrosPersonalizados(TrabajoInformeBean trabajoInforme,
+                                                Map<String, String> parametrosPersonalizados) {
+        if (parametrosPersonalizados == null || parametrosPersonalizados.isEmpty()) {
+            return;
+        }
+        parametrosPersonalizados.forEach(trabajoInforme::addParametro);
+    }
+
+    private TipoDocumentoBean obtenerTipoDocumento(TicketVentaAbono ticketVenta,
+                                                   IDatosSesion datosSesion)
+            throws TipoDocumentoNotFoundException, TipoDocumentoException {
+        return servicioTiposDocumentos.consultar(datosSesion, ticketVenta.getCabecera().getTipoDocumento());
+    }
+
+    private String resolverPlantilla(TicketVentaAbono ticketVenta,
+                                     TipoDocumentoBean tipoDocumento,
+                                     String plantillaSolicitada) {
+        if (StringUtils.isNotBlank(plantillaSolicitada)) {
+            return plantillaSolicitada.endsWith(".jasper") ? plantillaSolicitada : plantillaSolicitada + ".jasper";
+        }
+
+        if (tipoDocumento == null) {
+            return "facturaA4_Original.jasper";
+        }
+
+        if (PAIS_PORTUGAL.equals(tipoDocumento.getCodPais())) {
+            return esDevolucion(ticketVenta) ? "facturaDevolucionA4_PT.jasper" : "facturaA4_PT.jasper";
+        }
+        if (PAIS_CATALUNA.equals(tipoDocumento.getCodPais())) {
+            return "facturaA4_CA.jasper";
+        }
+        return "facturaA4_Original.jasper";
+    }
+
+    private boolean esDevolucion(TicketVentaAbono ticketVenta) {
+        if (ticketVenta.getCabecera() == null) {
+            return false;
+        }
+        String codigo = ticketVenta.getCabecera().getCodTipoDocumento();
+        return "FR".equalsIgnoreCase(codigo) || "NC".equalsIgnoreCase(codigo);
+    }
+
+    private byte[] generarPdf(TrabajoInformeBean trabajoInforme, String plantilla)
+            throws IOException, JRException {
+        String rutaBase = AppInfo.getInformesInfo().getRutaBase();
+        if (StringUtils.isBlank(rutaBase)) {
+            rutaBase = "." + File.separator;
+        }
+        File ficheroJasper = new File(rutaBase + DIRECTORIO_INFORMES + plantilla);
+        try (InputStream flujoJasper = new FileInputStream(ficheroJasper)) {
+            Object objetoJasper = JRLoader.loadObject(flujoJasper);
+            return JasperRunManager.runReportToPdf((net.sf.jasperreports.engine.JasperReport) objetoJasper,
+                    trabajoInforme.getParametros());
+        }
+    }
+
+    private DocumentoVentaImpresionRespuesta construirRespuesta(String uidDocumento,
+                                                                 OpcionesImpresionDocumentoVenta opciones,
+                                                                 byte[] pdf) {
+        DocumentoVentaImpresionRespuesta respuesta = new DocumentoVentaImpresionRespuesta();
+        respuesta.setUidDocumento(uidDocumento);
+        respuesta.setTipoMime(StringUtils.defaultIfBlank(opciones.getTipoMime(), MIMETYPE_POR_DEFECTO));
+        respuesta.setCopia(opciones.esCopia());
+        respuesta.setEnLinea(opciones.esEnLinea());
+        respuesta.setNombreArchivo(resolverNombreArchivo(uidDocumento, opciones));
+        respuesta.setDocumento(Base64.getEncoder().encodeToString(pdf));
+        return respuesta;
+    }
+
+    private String resolverNombreArchivo(String uidDocumento, OpcionesImpresionDocumentoVenta opciones) {
+        String nombreBase = StringUtils.isNotBlank(opciones.getNombreDocumentoSalida())
+                ? opciones.getNombreDocumentoSalida()
+                : uidDocumento;
+        if (!StringUtils.endsWithIgnoreCase(nombreBase, ".pdf")) {
+            nombreBase = nombreBase + ".pdf";
+        }
+        if (opciones.esCopia() && !nombreBase.toLowerCase(Locale.ROOT).contains("copia")) {
+            nombreBase = nombreBase.replaceFirst("(?i)\\.pdf$", "_copia.pdf");
+        }
+        return nombreBase;
+    }
+
+    private String obtenerFechaOrigen(Document documento) {
+        NodeList nodos = documento.getElementsByTagName("fechaTicketOrigen");
+        if (nodos == null || nodos.getLength() == 0 || nodos.item(0) == null) {
+            return null;
+        }
+        return nodos.item(0).getTextContent();
+    }
+
+    private String obtenerNumeroPedido(Document documento) throws XMLDocumentNodeNotFoundException {
+        XMLDocument documentoXml = new XMLDocument(documento);
+        XMLDocumentNode nodoPagos = documentoXml.getNodo("pagos", true);
+        if (nodoPagos == null) {
+            return null;
+        }
+        List<XMLDocumentNode> pagos = nodoPagos.getHijos("pago");
+        int indicePago = 0;
+        for (XMLDocumentNode nodoPago : pagos) {
+            XMLDocumentNode nodoDatosExtendidos = nodoPago.getNodo("extendedData", true);
+            LOGGER.debug("obtenerNumeroPedido() - pago[{}] datosExtendidos={}",
+                    indicePago++, nodoDatosExtendidos != null ? nodoDatosExtendidos.toString() : "<null>");
+            if (nodoDatosExtendidos == null) {
+                continue;
+            }
+            XMLDocumentNode nodoDocumento = nodoDatosExtendidos.getNodo("documento", true);
+            if (nodoDocumento != null) {
+                return nodoDocumento.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/OpcionesImpresionDocumentoVenta.java
+++ b/comerzzia-bricodepot-api-omnichannel/src/main/java/com/comerzzia/bricodepot/api/omnichannel/api/web/salesdocument/OpcionesImpresionDocumentoVenta.java
@@ -1,0 +1,55 @@
+package com.comerzzia.bricodepot.api.omnichannel.api.web.salesdocument;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class OpcionesImpresionDocumentoVenta {
+
+    private final String tipoMime;
+    private final boolean esCopia;
+    private final boolean enLinea;
+    private final String nombreDocumentoSalida;
+    private final String plantillaImpresion;
+    private final Map<String, String> parametrosPersonalizados;
+
+    public OpcionesImpresionDocumentoVenta(String tipoMime,
+                                           boolean esCopia,
+                                           boolean enLinea,
+                                           String nombreDocumentoSalida,
+                                           String plantillaImpresion,
+                                           Map<String, String> parametrosPersonalizados) {
+        this.tipoMime = tipoMime;
+        this.esCopia = esCopia;
+        this.enLinea = enLinea;
+        this.nombreDocumentoSalida = nombreDocumentoSalida;
+        this.plantillaImpresion = plantillaImpresion;
+        this.parametrosPersonalizados = parametrosPersonalizados == null
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(new HashMap<>(parametrosPersonalizados));
+    }
+
+    public String getTipoMime() {
+        return tipoMime;
+    }
+
+    public boolean esCopia() {
+        return esCopia;
+    }
+
+    public boolean esEnLinea() {
+        return enLinea;
+    }
+
+    public String getNombreDocumentoSalida() {
+        return nombreDocumentoSalida;
+    }
+
+    public String getPlantillaImpresion() {
+        return plantillaImpresion;
+    }
+
+    public Map<String, String> getParametrosPersonalizados() {
+        return parametrosPersonalizados;
+    }
+}

--- a/comerzzia-bricodepot-api-omnichannel/src/main/resources/comerzzia-api-context.xml
+++ b/comerzzia-bricodepot-api-omnichannel/src/main/resources/comerzzia-api-context.xml
@@ -18,6 +18,7 @@
 
     <context:component-scan base-package="com.comerzzia.api" />
     <context:component-scan base-package="com.comerzzia.bricodepot.api" />
+    <context:component-scan base-package="com.comerzzia.bricodepot.backoffice.services" />
     <context:component-scan base-package="com.comerzzia.core.servicios" />
     <context:component-scan base-package="com.comerzzia.core.basketcalculator" />
     <context:component-scan base-package="com.comerzzia.omnichannel.service" />     


### PR DESCRIPTION
## Summary
- renombrar el controlador REST y la capa de servicio de impresión de documentos de venta utilizando nomenclatura y mensajes en español
- encapsular las opciones de impresión y la respuesta con DTOs españolizados manteniendo la compatibilidad JSON existente
- refactorizar la preparación del informe Jasper con utilidades auxiliares más legibles en castellano

## Testing
- no se ejecutaron pruebas (dependencias propietarias no disponibles en el entorno)

------
https://chatgpt.com/codex/tasks/task_e_68de50a2a864832b8582c92c2835af85