### PR TITLE
Add backoffice services dependency to Brico omnichannel API

### DIFF
--- a/comerzzia-bricodepot-api-omnichannel/pom.xml
+++ b/comerzzia-bricodepot-api-omnichannel/pom.xml
@@ -27,12 +27,13 @@
 		<comerzzia.core.version>4.8.1-SNAPSHOT</comerzzia.core.version>
 		<comerzzia.pos.version>4.8.1-SNAPSHOT</comerzzia.pos.version>
 		
-		<comerzzia.api.ise.version>4.8-SNAPSHOT</comerzzia.api.ise.version>
-		<comerzzia.api.v1.version>1.2.0-SNAPSHOT</comerzzia.api.v1.version>
-		<comerzzia.api.loyalty.version>2.0.1-SNAPSHOT</comerzzia.api.loyalty.version>
-		<comerzzia.api.core.version>1.0.0-SNAPSHOT</comerzzia.api.core.version>
-		<comerzzia.api.core.services.version>2.0-SNAPSHOT</comerzzia.api.core.services.version>
-	</properties>
+                <comerzzia.api.ise.version>4.8-SNAPSHOT</comerzzia.api.ise.version>
+                <comerzzia.api.v1.version>1.2.0-SNAPSHOT</comerzzia.api.v1.version>
+                <comerzzia.api.loyalty.version>2.0.1-SNAPSHOT</comerzzia.api.loyalty.version>
+                <comerzzia.api.core.version>1.0.0-SNAPSHOT</comerzzia.api.core.version>
+                <comerzzia.api.core.services.version>2.0-SNAPSHOT</comerzzia.api.core.services.version>
+                <comerzzia.custom.backoffice.version>25-SNAPSHOT</comerzzia.custom.backoffice.version>
+        </properties>
 
 	<dependencies>
 		<dependency>
@@ -125,12 +126,17 @@
 			<artifactId>comerzzia-omnichannel-services</artifactId>
 			<version>4.8-SNAPSHOT</version>
 		</dependency>
-		<dependency>
-			<groupId>com.comerzzia.api.omnichannel</groupId>
-			<artifactId>comerzzia-api-omnichannel-web</artifactId>
-			<version>2.0-SNAPSHOT</version>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>com.comerzzia.api.omnichannel</groupId>
+                        <artifactId>comerzzia-api-omnichannel-web</artifactId>
+                        <version>2.0-SNAPSHOT</version>
+                </dependency>
+                <dependency>
+                        <groupId>com.comerzzia.bricodepot</groupId>
+                        <artifactId>comerzzia-custom-backoffice-services</artifactId>
+                        <version>${comerzzia.custom.backoffice.version}</version>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
## Summary
- add a property to manage the custom backoffice module version for the Brico omnichannel API
- include the custom backoffice services dependency so the API can use invoice printing services provided by the backoffice

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de58347c2c832bbdc8901772b3a185